### PR TITLE
Modernize workflows and checklist, integrate all open issues

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly

--- a/.github/workflows/convert-and-commit.yml
+++ b/.github/workflows/convert-and-commit.yml
@@ -1,17 +1,24 @@
 name: Convert markdown to Word
+
 on:
   push:
     branches:
       - main
+    paths:
+      - checklist.md
+
+permissions:
+  contents: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
 
 jobs:
   convert_via_pandoc:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-        with:
-          ref: ${{ github.event.push.head.ref }}
-      - uses: docker://pandoc/core:2.9
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: docker://pandoc/core:3.10.0.0
         with:
           args: >- # allows you to break string into multiple lines
             --standalone
@@ -19,9 +26,12 @@ jobs:
             checklist.md
       - name: ⤴ Commit updated version
         run: |
-          git config remote.origin.url 'https://${{secrets.GITHUB_TOKEN}}@github.com/potatoqualitee/froopyland-dr.git'
-          git config user.name potatoqualitee
-          git config user.email clemaire@gmail.com
-          git add .
-          git commit -am "update word"
-          git push
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add checklist.docx
+          if git diff --cached --quiet; then
+            echo "checklist.docx is already up to date"
+          else
+            git commit -m "Regenerate checklist.docx"
+            git push
+          fi

--- a/.github/workflows/test-convert.yml
+++ b/.github/workflows/test-convert.yml
@@ -1,20 +1,26 @@
-name: Convert markdown to Word
-on: push
+name: Test markdown conversion
+
+on:
+  pull_request:
+    paths:
+      - checklist.md
+
+permissions:
+  contents: read
 
 jobs:
-  temp_conversion_via_pandoc:
+  test_conversion_via_pandoc:
     runs-on: ubuntu-latest
-    env:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v2
-      - uses: docker://pandoc/core:2.9
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: docker://pandoc/core:3.10.0.0
         with:
           args: >- # allows you to break string into multiple lines
             --standalone
             --output=checklist.docx
             checklist.md
-      - uses: actions/upload-artifact@master
+      - name: Upload converted document for preview
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: checklist.docx
           path: checklist.docx

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,14 @@
+# Contributing
+
+Suggestions are welcome and encouraged! This checklist was crowdsourced from the start, and it gets better every time someone spots something missing.
+
+## How to contribute
+
+1. Edit [checklist.md](checklist.md) (or [README.md](README.md)) and submit a pull request.
+2. Do **not** edit `checklist.docx` directly — it is regenerated automatically by a GitHub Action whenever a change to `checklist.md` lands on `main`.
+3. When your PR touches `checklist.md`, a workflow converts it to Word and uploads the result as a build artifact, so you can preview the .docx before it's merged.
+
+## Guidelines
+
+- Keep entries generic and sanitized — this is a template. Real names, passwords and PINs don't belong here.
+- Plain language beats jargon. The audience is a grieving, non-technical loved one, not an engineer.

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ I put together an initial draft to answer these questions for my own wife, and t
 
 Within hours of this interaction, I created a Word document, printed it out, filled in a couple passwords manually, and then stored it in a fire proof bag.
 
-Here is a sanitized list that you can use for your own purposes. If anything is missing or you have suggestions, please feel free to submit a PR. Upon approval, the Word doc will be regenerated for others.
+Here is a sanitized list that you can use for your own purposes. If anything is missing or you have suggestions, please feel free to submit a PR (see [CONTRIBUTING.md](CONTRIBUTING.md)). Upon approval, the Word doc will be regenerated for others.
 
 So here is the checklist:
 
@@ -35,6 +35,5 @@ So here is the checklist:
 |----------|-------------|
 | [In Case You Get Hit by a Bus](https://www.amazon.com/Case-You-Get-Hit-Bus/dp/1523510471) | A comprehensive guide book on organizing your personal and business information for loved ones in case of emergency or death |
 | [The Next of Kin box](https://www.thenokbox.com/) | A physical emergency information storage solution - a fireproof box with checklist for organizing critical documents and information |
-| [Digital Legacy Trust](https://legacytrust.nz) | A New Zealand-based service that helps manage and distribute digital assets and information to designated beneficiaries |
 | [Rememory](https://github.com/eljojo/rememory) | A digital safe with multiple keys designed for non-techies, where important information can be split among trusted contacts and recovered after a tragic event |
 | [Evergreen Blogs](https://rishikeshs.com/journal/evergreen-blogs/) | A curated collection of personal blogs and websites with timeless content, reminding us of the importance of preserving digital legacies |

--- a/checklist.md
+++ b/checklist.md
@@ -61,7 +61,7 @@ You know how to use this since we've incorporated it into our lives.
 
 ### Homelabs
 
-* DO NOT SELL WITHOUT FORMATTING OR DESTROYING DISKS. This could be an identity theft disaster.
+* DO NOT SELL WITHOUT FORMATTING OR DESTROYING DISKS. This could be an identity theft disaster. This goes for drives of any kind — spinning hard drives, SSDs, and the little stick-shaped ones called M.2 or NVMe.
 * Janet can have my “big” black boxes (doesn’t need formatting) and my little black box called a NUC (needs formatting)
 * Peter can have my Macs
   * Needs formatting AND needs to follow instructions from Apple to disconnect it from Find My or they’ll be prevented from using it
@@ -112,10 +112,26 @@ Fortunately, you're familiar with this because I require you to be :blush:. This
   * Authy 
     * I default to this most of the time unless it's not available
   * Microsoft Authenticator
+* If my phone is lost or wiped, Microsoft Authenticator can be restored: install it on a new phone, sign in with me@fake.com, and the codes come back from its cloud backup
+  * Cloud-backed authenticator apps like this are the easiest for you to recover, which is why I use them for the important accounts
+* My YubiKey (a little USB stick that unlocks some accounts when you plug it in) is stored in _____. It unlocks _____ and the spare is in _____
+* The important accounts also handed out one-time backup/recovery codes when I set up 2FA — they're printed and stored with this document (see "Keep a hard copy" below)
 * Some accounts require a US phone number for SMS, so use the me@fake.com Google Voice account phone number
   * If you see that they sent it to phone number 555-555-5555, then that is the Google Voice account
 * Remember to avoid using SMS for 2FA if it's possible, because it's less safe
 * Keep using Authy for your own accounts when you can
+
+### Keep a hard copy
+
+Hopefully you're reading this from the printout in the fireproof bag. Some things only exist on paper on purpose:
+
+* My KeePass master password (written on the printed copy of this document)
+* The PIN to unlock my phone
+* The 2FA backup/recovery codes mentioned above
+
+I have a calendar reminder every 6 months to reprint this when something changes. If this printout looks ancient, check for a newer version before trusting the details.
+
+If keeping paper up to date sounds like a chore for your own copy of this list, password managers can handle it digitally — Bitwarden Emergency Access and 1Password's Emergency Kit give a trusted person access after a waiting period, with nothing to reprint.
 
 ### Cloud Subscriptions
 
@@ -161,7 +177,8 @@ This little black box stores all of our backups that we don't want going to the 
 
 ### Tech Tips
 
-* Do not EVER sell anything with a hard drive without formatting the hard drives first. Ask any of our tech friends to help.
+* Do not EVER sell anything with storage in it without wiping it first — that means spinning hard drives, SSDs, and the little stick-shaped ones called M.2 or NVMe. Ask any of our tech friends to help.
+* A simple format does not reliably erase an SSD. Use the manufacturer's secure-erase tool, or if the drive was always encrypted, destroying the encryption key is enough. When in doubt, keep the drive or have a tech friend physically destroy it — never just throw it in the bin.
 * Do not EVER try to sell an Apple product without following their instructions to wipe before reselling. Apple is special and associates Find My with your account so it prevents theft. The person won’t be able to use it if you don’t unregister the device.
 
 ## Input
@@ -274,7 +291,24 @@ Ask our accountant or look over our finances to see any new 1099s if this list g
 
 Also, if you feel overwhelmed by all of this, ask her to perhaps switch the way we pay our taxes and don't take deductions.
 
+### Legal documents
+
+* Our wills are stored _____ and the attorney has the originals
+* Powers of attorney and healthcare directives are stored with the wills
+* Our attorney is _____ — contact them early, they'll walk you through what needs to be filed and when
+
+### For retirees
+
+If you're adapting this checklist and you're retired (or close to it), your partner will also need:
+
+* Who to notify at the pension fund and how survivor payments get arranged
+* Whether health/sickness insurance continues for the surviving partner and what they must do to keep it
+* How savings accounts for grandchildren or other beneficiaries transfer or continue
+* In much of Europe, banks freeze ALL of the deceased's accounts — including joint ones — as soon as they're notified. Talk to your bank in advance so your partner has accessible funds while the estate is settled (see the set-aside note under Bank Accounts).
+
 ### Answers to common security questions
+
+Check KeePass first: for most accounts, my security answers are randomly generated nonsense stored in the notes or custom fields of that account's entry, because honest answers can be guessed or googled. The answers below are only for the old accounts where I answered honestly.
 
 * First dog: Jackson
 * Dad's middle name: Henry
@@ -288,3 +322,20 @@ Also, if you feel overwhelmed by all of this, ask her to perhaps switch the way 
 * Medicine cabinet PIN: 59938
 * Weapons cabinet PIN: 9119119
 * Safe combo: Left - 89, right 33, Spin twice left then: 51
+
+## Final wishes
+
+### Obituary and service
+
+* Notes for my obituary are in _____ — the highlights I'd want mentioned and the things I'd rather you leave out
+* Songs and readings for the service: _____
+* Cremation or burial preference: _____
+
+### Pets
+
+* Our vet is _____ (name and phone)
+* Food, meds and quirks: _____
+* _____ has agreed to take them if it's too much
+* Current photos for ID (in case they bolt during the chaos) are in _____
+
+The wills, powers of attorney and our attorney's contact info are under Legal documents above.

--- a/checklist.md
+++ b/checklist.md
@@ -2,17 +2,17 @@
 
 If you are reading this, I, like Tommy, have disappeared to Froopyland and I miss you already. There's a lot here, but the first order of business is telling people.
 
-Contact the following friends and family directly before announcing it on Twitter. Open up my laptop, create a note, then copy/paste it to:
+Contact the following friends and family directly before announcing it on X (Twitter). Open up my laptop, create a note, then copy/paste it to:
 
 * iMessages: Blake, Brother, Brother 2
 * WhatsApp: Aaron
 * Facebook: Dad, dad’s phone number is in my phone too
-* Skype: Peter
+* Signal: Peter
 * Discord: Look in my chat list and message anyone I've talked about recently. So far, it's David, Jenn and Claudette.
 * Google chat or email: Melanie
 * Instagram or email: JoeB
 
-Then let ppl on Twitter, Facebook and Instagram know.
+Then let ppl on X (Twitter), Facebook and Instagram know.
 
 ## Tech
 
@@ -29,9 +29,9 @@ Add me@fake.com to your phone, actually, since that's where we get our shipping 
 
 ### Domains and blogs
 
-* All of my domains are managed via Google Domains and CloudFlare
-  * Google Domains auto renews and needs an updated Credit Card to keep going
-* xyz.io – Keep this paid via Google Domains or transfer to Danielle Smith 
+* All of my domains are managed via Squarespace Domains and Cloudflare
+  * Squarespace auto renews and needs an updated Credit Card to keep going
+* xyz.io – Keep this paid via Squarespace or transfer to Danielle Smith 
 * fakblog.com – Transfer to Blake
 
 ### Password Managers
@@ -57,7 +57,7 @@ You know how to use this since we've incorporated it into our lives.
   * Click Settings
   * Click the big thing at the top with my name
   * Click Subscriptions
-  * Delete anything you don’t want like Wondery+, Twitter, or Apple News
+  * Delete anything you don’t want like Wondery+, X (Twitter), or Apple News
 
 ### Homelabs
 
@@ -76,7 +76,7 @@ You know how to use this since we've incorporated it into our lives.
 ### Restarting network services
 
 * If the Internet goes out, restart the black modem like you always do (by waiting 10 seconds). If that doesn't work, unplug it physically, then physically plug it back in.
-* If that doesn't work, unplug the white disk upstairs and the white disk downtairs. Wait literally 20 minutes because Unifi is wild and takes forever to restart.
+* If that doesn't work, unplug the white disk upstairs and the white disk downstairs. Wait literally 20 minutes because Unifi is wild and takes forever to restart.
 * If that doesn't work either, check to see if there are any voo outages. If not, wait or call Peter.
 
 ### Home automation / IoT (Hue, etc)
@@ -98,9 +98,9 @@ Considering that, you might want to ask Michelle to setup the ISP's built-in wif
 ### Social Media accounts
 
 * Everything can be logged in with KeePass + the multi-factor apps on my phone (Authy or Microsoft Authenticator)
-* Don’t close Twitter for a few years
-  * If you sell my Twitter, make it worth your time, like 1 million then ask a friend to delete all my old posts
-  * This will probably require some sort of service because Twitter makes things hard
+* Don’t close X (Twitter) for a few years
+  * If you sell my X account, make it worth your time, like 1 million then ask a friend to delete all my old posts
+  * This will probably require some sort of service because X makes things hard
 * Export and close FB, I only stayed there for Niki's memorial page and my business page anyway
 * Instagram may be enjoyable for you to look back on since it's just us on vacation :kiss:
 
@@ -112,8 +112,8 @@ Fortunately, you're familiar with this because I require you to be :blush:. This
   * Authy 
     * I default to this most of the time unless it's not available
   * Microsoft Authenticator
-* Some accounts require a US phone number for SMS, so use the me@fake.com Skype account phone number
-  * If you see that they sent it to phone number 555-555-5555, then that is the Skype account
+* Some accounts require a US phone number for SMS, so use the me@fake.com Google Voice account phone number
+  * If you see that they sent it to phone number 555-555-5555, then that is the Google Voice account
 * Remember to avoid using SMS for 2FA if it's possible, because it's less safe
 * Keep using Authy for your own accounts when you can
 
@@ -121,7 +121,7 @@ Fortunately, you're familiar with this because I require you to be :blush:. This
 
 SUPER IMPORTANT because these bills can get big quickly
 
-* Microsoft Azure + Power BI - to delete sponsorship subscription and transfer resources – contact Michelle and have her walk you through it. The phone number is listed on [this page](https://docs.microsoft.com/en-us/microsoft-365/admin/get-help-support?view=o365-worldwide&tabs=online#phone-support): +1-800-865-9408
+* Microsoft Azure + Power BI - to delete sponsorship subscription and transfer resources – contact Michelle and have her walk you through it. The phone number is listed on [this page](https://learn.microsoft.com/en-us/microsoft-365/admin/get-help-support#phone-support): +1-800-865-9408
 * Amazon Web Services charges 5 cents a month and is hooked up to our Amazon account, so you can just leave it forever
 * Appveyor – Billy Dominguez will know what to do. Please get in touch with him at some point because if this bill isn't paid each year, then the tests will fail in our repository.
 
@@ -157,7 +157,7 @@ This little black box stores all of our backups that we don't want going to the 
 
 * BlueHost – let Blake know to look out for a bill each March as this is where fakblog.com is hosted
   * Transfer ownership to Blake and have him contact Bluehost support to reset all passwords
-* CloudFlare – this does some advanced shit but is free. Login via Authy. Blake may want to know this too.
+* Cloudflare – this does some advanced shit but is free. Login via Authy. Blake may want to know this too.
 
 ### Tech Tips
 
@@ -172,7 +172,7 @@ This is the section where money lands or exists.
 
 We have a couple bank accounts that serve different purposes. One is good for paying international bills, the other comes with some great insurance, and yet another is an old account I've had for a while. It's good for your credit to have a couple bank accounts too.
 
-You use PayPal a lot, so don't close it but feel free to ask a friend to help you change the email addres if you want. It may come with further confirmation.
+You use PayPal a lot, so don't close it but feel free to ask a friend to help you change the email address if you want. It may come with further confirmation.
 
 * Fak Bank
   * Checking / Savings


### PR DESCRIPTION
## What

Three commits that bring the repo current:

### Workflows and repo hygiene
- `actions/checkout` v2 → v7.0.1 and `actions/upload-artifact` `@master` → v7.0.1, pinned to commit SHAs; pandoc 2.9 → 3.10
- Fixed the docx-commit push URL that still pointed at the old `froopyland-dr` repo name — now uses the checkout token with a least-privilege `permissions: contents: write` block
- Both workflows only run when `checklist.md` changes; the test conversion now runs on **pull requests** (it previously never ran for fork PRs, which is who it's for) and uploads the converted docx as a preview artifact
- The commit step skips when the docx is unchanged, commits as `github-actions[bot]`, and a concurrency group prevents racing pushes
- Added Dependabot for monthly action updates and a short CONTRIBUTING.md

### Dated content
- Skype is retired → Signal for the contact example, Google Voice for the US SMS number (closes #29)
- Google Domains → Squarespace Domains, Twitter → X (Twitter), CloudFlare → Cloudflare, docs.microsoft.com → learn.microsoft.com
- Removed the Digital Legacy Trust resource — legacytrust.nz no longer resolves
- Typo fixes: downtairs, addres

### Issue integrations
- 2FA section: Microsoft Authenticator cloud-backup restore steps, a hardware-key location template, and where recovery codes are printed; new Legal documents subsection for wills/powers of attorney/attorney contact (closes #8)
- New For retirees subsection: pension survivor payments, insurance continuity, beneficiary accounts, and the European account-freeze warning (closes #14)
- New Keep a hard copy subsection: what only exists on paper, a reprint cadence, and password-manager emergency access as the no-paper alternative (closes #15)
- New Final wishes section: obituary notes, service preferences, and pet care, cherry-picked from Ralph's fork (closes #24)
- Disk-wiping warnings now cover SSDs and M.2/NVMe, with a tech tip that a simple format does not erase an SSD (closes #27)
- Security questions section now points to randomly generated answers in the password manager first (closes #30)

## Test plan

- YAML for both workflows and dependabot.yml validated
- Action SHAs verified against the tags on github.com; learn.microsoft.com replacement link returns 200; legacytrust.nz confirmed NXDOMAIN
- Ran the exact `pandoc/core:3.10.0.0` Docker image against the updated checklist.md locally — converts cleanly
- The new PR-triggered test workflow will run on this PR itself as a live check
- `checklist.docx` is intentionally untouched here; the workflow regenerates it on merge to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)